### PR TITLE
#6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prettier-plugin-tailwindcss": "^0.5.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-responsive": "^10.0.0",
     "rehype-pretty-code": "^0.10.1",
     "rehype-stringify": "^10.0.0",
     "remark-gfm": "^3.0.1",

--- a/src/app/blog/page.js
+++ b/src/app/blog/page.js
@@ -3,9 +3,8 @@ import styles from './styles.module.css';
 import Image from 'next/image';
 
 import { getPosts } from '@/lib/get-posts';
+import ArticleList from '@components/article-list';
 import More from '@components/more';
-import ThumbnailNormal from '@components/thumbnail/normal';
-import ThumbnailLarge from '@components/thumbnail/large';
 
 export const metadata = {
   title: 'Blog ••• poodlepoodle',
@@ -15,9 +14,6 @@ export const metadata = {
 
 export default async function Page() {
   const posts = await getPosts();
-  const sortedPosts = posts.sort((a, b) => new Date(b.date) - new Date(a.date));
-  const upperPosts = sortedPosts.slice(0, 2);
-  const lowerPosts = sortedPosts.slice(2, 5);
 
   return (
     <section className={styles.layout}>
@@ -35,31 +31,7 @@ export default async function Page() {
           </span>
         </div>
 
-        <div className={styles.postrow__upper}>
-          {upperPosts.map(({ title, slug, date }, idx) =>
-            idx === 0 ? (
-              <ThumbnailLarge
-                key={slug}
-                title={title}
-                slug={slug}
-                date={date}
-              />
-            ) : (
-              <ThumbnailNormal
-                key={slug}
-                title={title}
-                slug={slug}
-                date={date}
-              />
-            )
-          )}
-        </div>
-
-        <div className={styles.postrow__lower}>
-          {lowerPosts.map(({ title, slug, date }) => (
-            <ThumbnailNormal key={slug} title={title} slug={slug} date={date} />
-          ))}
-        </div>
+        <ArticleList posts={posts} />
 
         <div className={styles.centered__row}>
           <More />

--- a/src/app/blog/styles.module.css
+++ b/src/app/blog/styles.module.css
@@ -36,13 +36,14 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0 2.5rem;
 
   color: #6082b6;
   text-align: center;
   font-size: 0.875rem;
   font-style: normal;
   font-weight: 600;
-  line-height: normal;
+  line-height: 1.25rem;
 }
 
 .centered__row {

--- a/src/app/blog/styles.module.css
+++ b/src/app/blog/styles.module.css
@@ -45,27 +45,6 @@
   line-height: normal;
 }
 
-.postrow__upper {
-  position: relative;
-  width: 100%;
-  flex-shrink: 0;
-
-  display: flex;
-  justify-content: space-between;
-}
-
-.postrow__lower {
-  position: relative;
-  width: 100%;
-  flex-shrink: 0;
-
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: auto;
-  grid-column-gap: 1.5rem;
-  grid-row-gap: 3rem;
-}
-
 .centered__row {
   position: relative;
   width: 100%;

--- a/src/app/components/article-list/articlelist.module.css
+++ b/src/app/components/article-list/articlelist.module.css
@@ -1,0 +1,31 @@
+.postrow {
+  position: relative;
+  width: 100%;
+  flex-shrink: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  row-gap: 1.5rem;
+}
+
+.postrow__upper {
+  position: relative;
+  width: 100%;
+  flex-shrink: 0;
+
+  display: flex;
+  justify-content: space-between;
+}
+
+.postrow__lower {
+  position: relative;
+  width: 100%;
+  flex-shrink: 0;
+
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: auto;
+  grid-column-gap: 1.5rem;
+  grid-row-gap: 3rem;
+}

--- a/src/app/components/article-list/index.jsx
+++ b/src/app/components/article-list/index.jsx
@@ -1,0 +1,78 @@
+'use client';
+
+import styles from './articlelist.module.css';
+
+import { useEffect, useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+
+import ThumbnailRow from '@components/thumbnail/row';
+import ThumbnailNormal from '@components/thumbnail/normal';
+import ThumbnailLarge from '@components/thumbnail/large';
+
+export default function ArticleList({ posts }) {
+  const [isMobile, setIsMobile] = useState(false);
+  const mobile = useMediaQuery({ maxWidth: 840 });
+
+  useEffect(() => {
+    if (mobile) {
+      setIsMobile(true);
+    } else {
+      setIsMobile(false);
+    }
+  }, [mobile]);
+
+  const sortedPosts = posts.sort((a, b) => new Date(b.date) - new Date(a.date));
+  const upperPosts = sortedPosts.slice(0, 2);
+  const lowerPosts = sortedPosts.slice(2, 5);
+
+  return (
+    <>
+      {isMobile ? (
+        <div className={styles.postrow}>
+          {sortedPosts.map(({ title, slug, tags, date }) => (
+            <ThumbnailRow
+              key={slug}
+              title={title}
+              slug={slug}
+              tags={tags}
+              date={date}
+            />
+          ))}
+        </div>
+      ) : (
+        <>
+          <div className={styles.postrow__upper}>
+            {upperPosts.map(({ title, slug, date }, idx) =>
+              idx === 0 ? (
+                <ThumbnailLarge
+                  key={slug}
+                  title={title}
+                  slug={slug}
+                  date={date}
+                />
+              ) : (
+                <ThumbnailNormal
+                  key={slug}
+                  title={title}
+                  slug={slug}
+                  date={date}
+                />
+              )
+            )}
+          </div>
+
+          <div className={styles.postrow__lower}>
+            {lowerPosts.map(({ title, slug, date }) => (
+              <ThumbnailNormal
+                key={slug}
+                title={title}
+                slug={slug}
+                date={date}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/app/components/thumbnail/row/row.module.css
+++ b/src/app/components/thumbnail/row/row.module.css
@@ -13,13 +13,13 @@
 }
 
 .content__container {
+  min-width: 25rem;
   flex: 1;
+  padding: 2rem;
 
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-
-  padding: 2rem;
 }
 
 .top__area {
@@ -36,7 +36,6 @@
 
 .thumbnail__container {
   position: relative;
-
   width: 13.875rem;
   height: 13.875rem;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,6 +538,11 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
@@ -958,6 +963,11 @@ html-void-elements@^3.0.0:
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz"
@@ -1138,7 +1148,7 @@ longest-streak@^3.0.0:
   resolved "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1159,6 +1169,13 @@ markdown-table@^3.0.0:
   version "3.0.3"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
+
+matchmediaquery@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.4.2.tgz#22582bd4ae63ad9f54c53001bba80cbed0f7eafa"
+  integrity sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 mdast-util-definitions@^5.0.0:
   version "5.1.2"
@@ -1869,7 +1886,7 @@ normalize-range@^0.1.2:
   resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -2032,6 +2049,15 @@ prettier-plugin-tailwindcss@^0.5.4:
   resolved "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.12.tgz"
   integrity sha512-o74kiDBVE73oHW+pdkFSluHBL3cYEvru5YgEqNkBMFF7Cjv+w1vI565lTlfoJT4VLWDe0FMtZ7FkE/7a4pMXSQ==
 
+prop-types@^15.6.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^6.0.0:
   version "6.4.1"
   resolved "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz"
@@ -2049,6 +2075,21 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-responsive@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-10.0.0.tgz#657c7a90823cd565f43aa5918bd8eb0cd2c91c91"
+  integrity sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.4.2"
+    prop-types "^15.6.1"
+    shallow-equal "^3.1.0"
 
 react@18.2.0:
   version "18.2.0"
@@ -2187,6 +2228,11 @@ server-only@^0.0.1:
   resolved "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz"
   integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
+shallow-equal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-3.1.0.tgz#e7a54bac629c7f248eff6c2f5b63122ba4320bec"
+  integrity sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
@@ -2247,6 +2293,7 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2273,6 +2320,7 @@ stringify-entities@^4.0.0:
     character-entities-legacy "^3.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
close #6 

- `react-responsive`의 `useMediaQuery` 훅을 사용해서 가로 840px 이하의 경우에 모바일 레이아웃을 적용했습니다.
- Next.js의 prerender 때문에 발생하는 hydration error를 방지하기 위해 공식 문서에서 제시한 대로 `useEffect`를 활용했습니다.
  - https://nextjs.org/docs/messages/react-hydration-error

|기기 사이즈|스크린샷|
|:--:|:--:|
|over 840px|<img src = "https://github.com/poodlepoodle/poodle-blog-nextjs/assets/6462456/1532eab2-36d3-40ec-9def-2f9835519936"  height="480" />|
|under 840px|<img src = "https://github.com/poodlepoodle/poodle-blog-nextjs/assets/6462456/8840995f-4952-403d-b5a8-98a5e7d5e4bb" height="480" />|
